### PR TITLE
Fixing pydantic validation errors on upload_model.py

### DIFF
--- a/dippy_subnet/upload_model.py
+++ b/dippy_subnet/upload_model.py
@@ -167,6 +167,8 @@ async def main(config: bt.config):
         namespace=repo_namespace,
         name=repo_name,
         chat_template=config.chat_template,
+        hash=None, 
+        commit=None,
         competition_id=config.competition_id,
     )
 
@@ -196,7 +198,7 @@ async def main(config: bt.config):
         namespace=repo_namespace,
         name=repo_name,
         chat_template=config.chat_template, 
-        hash=regenerate_hash(repo_namespace, repo_name, config.chat_template, config.competition_id), 
+        hash=str(regenerate_hash(repo_namespace, repo_name, config.chat_template, config.competition_id)), 
         commit=model_id_with_commit.commit,
         competition_id=config.competition_id,
     )


### PR DESCRIPTION
ModelId needs a specific format of input arguments and the prior code missed the hash and commit arguments.  To fix this, 
1. hash and commit arguments were added on line 170 and line 171
2. hash takes input of string (str) on line 201, was added accordingy