### PR TITLE
Update validator.py for BP with set_weights

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -384,7 +384,7 @@ class Validator:
                     wallet=self.wallet,
                     uids=self.metagraph.uids,
                     weights=adjusted_weights,
-                    wait_for_inclusion=False,
+                    wait_for_inclusion=True,
                     version_key=constants.weights_version_key,
                 )
                 weights_report = {"weights": {}}


### PR DESCRIPTION
Helps with the pesky

> Set weights                   Failed: {'code': 1014, 'message': 'Priority is too low: (18446744073709551615 vs 18446744073709551615)', 'data': 'The transaction has too low priority to replace another transaction already in the pool.'}

From the church of rao discord

![image](https://github.com/user-attachments/assets/7b8261ab-80cd-40a8-8cab-e4c46372dfd9)

https://discord.com/channels/1120750674595024897/1146169709683822643/1275837157851791360