### PR TITLE
fix(coherence):fix dataset format

### DIFF
--- a/scoring/coherence_score.py
+++ b/scoring/coherence_score.py
@@ -133,7 +133,9 @@ def calculate_coherence_score(model: LLM, dataset_formatter, messages, verbose=F
         for i, (conversation, max_turn) in enumerate(zip(conversations, max_messages)):
             if turn < max_turn:
                 new_input = dataset_formatter.new_input(conversation)
-
+                if conversation[-1]["role"] == "assistant":
+                    new_input = new_input[: -len("assistant\n")]
+                    new_input = f"{new_input}user\n"
                 batch_prompts.append(new_input)
                 active_conversations.append(i)
 


### PR DESCRIPTION
In the original codebase, during the process of generating messages for coherence scoring, the data was processed using the chatml prompt template. However, the model is generating both user and assistant messages. To ensure the correct behavior when generating user messages, the prompt should end with `<|im_start|>user\n`.

I have updated the code to fix this issue.